### PR TITLE
chore: up revm

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To run tests in a project, from the projects root:
 $ docker run --rm \
     -v $(pwd):/app/foundry \
     -u $(id -u):$(id -g) \
-    jxom/foundry-alphanet:latest \
+    ghcr.io/paradigmxyz/foundry-alphanet:latest \
     --foundry-directory /app/foundry \
     --foundry-command "test -vvv"
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # foundry-alphanet
 
-Tools built around the patched versions of forge and the solidity compiler from
-[clabby/eip-3074-foundry], which support [EIP-3074] instructions.
+Tools built around the patched versions of revm, forge, and the solidity compiler from
+[anton-rs/3074-invokers], which support [EIP-3074] instructions.
 
 We intend to further roll out Foundry patches to support other EVM modifications such as
 new opcodes or precompiles.
@@ -53,7 +53,7 @@ To run tests in a project, from the projects root:
 $ docker run --rm \
     -v $(pwd):/app/foundry \
     -u $(id -u):$(id -g) \
-    ghcr.io/paradigmxyz/foundry-alphanet:latest \
+    jxom/foundry-alphanet:latest \
     --foundry-directory /app/foundry \
     --foundry-command "test -vvv"
 ```

--- a/README.md
+++ b/README.md
@@ -60,5 +60,5 @@ $ docker run --rm \
 In this case we have signalled forge that we want increased verbosity in the test
 output passing `test -vvvv` to `--foundry-command`.
 
-[clabby/eip-3074-foundry]: https://github.com/clabby/eip-3074-foundry
+[anton-rs/3074-invokers]: https://github.com/anton-rs/3074-invokers
 [EIP-3074]: https://eips.ethereum.org/EIPS/eip-3074

--- a/patches/forge.diff
+++ b/patches/forge.diff
@@ -1,5 +1,5 @@
 diff --git a/Cargo.lock b/Cargo.lock
-index 67259910005..88eb5b9d118 100644
+index 67259910..c330d8d1 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
 @@ -2082,7 +2082,7 @@ dependencies = [
@@ -106,7 +106,7 @@ index 67259910005..88eb5b9d118 100644
  name = "revm"
  version = "3.5.0"
 -source = "git+https://github.com/bluealloy/revm?branch=reth_freeze#b00ebab8b3477f87e3d876a11b8f18d00a8f4103"
-+source = "git+https://github.com/clabby/revm?branch=cl/eip-3074#7b6365ab030f94b88fde70c934af736a58ae2e04"
++source = "git+https://github.com/wevm/revm?branch=jxom/eip-3074#1ddd520c938bb50ddf4f8493a640f73b0924691c"
  dependencies = [
   "auto_impl",
   "revm-interpreter",
@@ -115,7 +115,7 @@ index 67259910005..88eb5b9d118 100644
  name = "revm-interpreter"
  version = "1.3.0"
 -source = "git+https://github.com/bluealloy/revm?branch=reth_freeze#b00ebab8b3477f87e3d876a11b8f18d00a8f4103"
-+source = "git+https://github.com/clabby/revm?branch=cl/eip-3074#7b6365ab030f94b88fde70c934af736a58ae2e04"
++source = "git+https://github.com/wevm/revm?branch=jxom/eip-3074#1ddd520c938bb50ddf4f8493a640f73b0924691c"
  dependencies = [
   "revm-primitives",
   "serde",
@@ -124,7 +124,7 @@ index 67259910005..88eb5b9d118 100644
  name = "revm-precompile"
  version = "2.2.0"
 -source = "git+https://github.com/bluealloy/revm?branch=reth_freeze#b00ebab8b3477f87e3d876a11b8f18d00a8f4103"
-+source = "git+https://github.com/clabby/revm?branch=cl/eip-3074#7b6365ab030f94b88fde70c934af736a58ae2e04"
++source = "git+https://github.com/wevm/revm?branch=jxom/eip-3074#1ddd520c938bb50ddf4f8493a640f73b0924691c"
  dependencies = [
   "aurora-engine-modexp",
   "c-kzg",
@@ -141,7 +141,7 @@ index 67259910005..88eb5b9d118 100644
  name = "revm-primitives"
  version = "1.3.0"
 -source = "git+https://github.com/bluealloy/revm?branch=reth_freeze#b00ebab8b3477f87e3d876a11b8f18d00a8f4103"
-+source = "git+https://github.com/clabby/revm?branch=cl/eip-3074#7b6365ab030f94b88fde70c934af736a58ae2e04"
++source = "git+https://github.com/wevm/revm?branch=jxom/eip-3074#1ddd520c938bb50ddf4f8493a640f73b0924691c"
  dependencies = [
   "alloy-primitives",
   "alloy-rlp",
@@ -153,14 +153,14 @@ index 67259910005..88eb5b9d118 100644
 + "secp256k1",
   "serde",
  ]
-
+ 
 diff --git a/Cargo.toml b/Cargo.toml
-index 19a26c63bb2..6db993d054b 100644
+index 19a26c63..38ff559a 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
 @@ -187,17 +187,17 @@ tower-http = "0.4"
  #ethers-solc = { path = "../ethers-rs/ethers-solc" }
-
+ 
  [patch.crates-io]
 -ethers = { git = "https://github.com/gakonst/ethers-rs", rev = "f0e5b194f09c533feb10d1a686ddb9e5946ec107" }
 -ethers-core = { git = "https://github.com/gakonst/ethers-rs", rev = "f0e5b194f09c533feb10d1a686ddb9e5946ec107" }
@@ -184,13 +184,13 @@ index 19a26c63bb2..6db993d054b 100644
 +ethers-middleware = { git = "https://github.com/clabby/ethers-rs", branch = "cl/call-type-3074" }
 +ethers-solc = { git = "https://github.com/clabby/ethers-rs", branch = "cl/call-type-3074" }
 +
-+revm = { git = "https://github.com/clabby/revm", branch = "cl/eip-3074" }
-+revm-interpreter = { git = "https://github.com/clabby/revm", branch = "cl/eip-3074" }
-+revm-precompile = { git = "https://github.com/clabby/revm", branch = "cl/eip-3074" }
-+revm-primitives = { git = "https://github.com/clabby/revm", branch = "cl/eip-3074" }
-
++revm = { git = "https://github.com/wevm/revm", branch = "jxom/eip-3074" }
++revm-interpreter = { git = "https://github.com/wevm/revm", branch = "jxom/eip-3074" }
++revm-precompile = { git = "https://github.com/wevm/revm", branch = "jxom/eip-3074" }
++revm-primitives = { git = "https://github.com/wevm/revm", branch = "jxom/eip-3074" }
+ 
 diff --git a/crates/anvil/core/src/eth/transaction/mod.rs b/crates/anvil/core/src/eth/transaction/mod.rs
-index 68cd9b48fa8..b07914480f8 100644
+index 68cd9b48..b0791448 100644
 --- a/crates/anvil/core/src/eth/transaction/mod.rs
 +++ b/crates/anvil/core/src/eth/transaction/mod.rs
 @@ -137,7 +137,7 @@ impl EthTransactionRequest {
@@ -212,9 +212,9 @@ index 68cd9b48fa8..b07914480f8 100644
 +        let [first, s @ ..] = rlp.data()? else { return Err(DecoderError::Custom("empty slice")) };
          // "advance" the header, see comments in fastrlp impl below
          let s = if s.is_empty() { &rlp.as_raw()[1..] } else { s };
-
+ 
 diff --git a/crates/anvil/src/eth/util.rs b/crates/anvil/src/eth/util.rs
-index 4181df4e8d4..d3c6e9d7e97 100644
+index 4181df4e..d3c6e9d7 100644
 --- a/crates/anvil/src/eth/util.rs
 +++ b/crates/anvil/src/eth/util.rs
 @@ -79,6 +79,7 @@ pub fn to_precompile_id(spec_id: SpecId) -> revm::precompile::SpecId {
@@ -226,7 +226,7 @@ index 4181df4e8d4..d3c6e9d7e97 100644
          SpecId::REGOLITH |
          SpecId::CANYON |
 diff --git a/crates/anvil/src/genesis.rs b/crates/anvil/src/genesis.rs
-index 23afd5fc3c9..43ba7030b80 100644
+index 23afd5fc..43ba7030 100644
 --- a/crates/anvil/src/genesis.rs
 +++ b/crates/anvil/src/genesis.rs
 @@ -199,6 +199,8 @@ pub struct Config {
@@ -239,7 +239,7 @@ index 23afd5fc3c9..43ba7030b80 100644
      #[serde(default, skip_serializing_if = "Option::is_none")]
      pub terminal_total_difficulty_passed: Option<bool>,
 diff --git a/crates/anvil/src/hardfork.rs b/crates/anvil/src/hardfork.rs
-index 42745fb80ce..62e20c3e9e5 100644
+index 42745fb8..62e20c3e 100644
 --- a/crates/anvil/src/hardfork.rs
 +++ b/crates/anvil/src/hardfork.rs
 @@ -22,6 +22,7 @@ pub enum Hardfork {
@@ -251,13 +251,13 @@ index 42745fb80ce..62e20c3e9e5 100644
      Latest,
  }
 @@ -48,6 +49,7 @@ impl Hardfork {
-
+ 
              // TODO: set block number after activation
              Hardfork::Cancun => unreachable!(),
 +            Hardfork::Prague => unreachable!(),
          }
      }
-
+ 
 @@ -100,6 +102,10 @@ impl Hardfork {
                  // TODO: set fork hash once known
                  ForkId { hash: ForkHash([0xc1, 0xfd, 0xf1, 0x81]), next: 0 }
@@ -278,7 +278,7 @@ index 42745fb80ce..62e20c3e9e5 100644
              _ => return Err(format!("Unknown hardfork {s}")),
          };
 @@ -156,6 +163,7 @@ impl From<Hardfork> for SpecId {
-
+ 
              // TODO: switch to latest after activation
              Hardfork::Cancun => SpecId::CANCUN,
 +            Hardfork::Prague => SpecId::PRAGUE,
@@ -286,7 +286,7 @@ index 42745fb80ce..62e20c3e9e5 100644
      }
  }
 diff --git a/crates/cast/bin/cmd/create2.rs b/crates/cast/bin/cmd/create2.rs
-index 661ea3cb185..44f9bef1bf1 100644
+index 661ea3cb..44f9bef1 100644
 --- a/crates/cast/bin/cmd/create2.rs
 +++ b/crates/cast/bin/cmd/create2.rs
 @@ -196,7 +196,7 @@ impl Create2Args {
@@ -296,7 +296,7 @@ index 661ea3cb185..44f9bef1bf1 100644
 -                        break None;
 +                        break None
                      }
-
+ 
                      // Calculate the `CREATE2` address.
 @@ -211,7 +211,7 @@ impl Create2Args {
                      if regex.matches(s).into_iter().count() == regex_len {
@@ -305,10 +305,10 @@ index 661ea3cb185..44f9bef1bf1 100644
 -                        break Some((salt.0, addr));
 +                        break Some((salt.0, addr))
                      }
-
+ 
                      // Increment the salt for the next iteration.
 diff --git a/crates/cast/bin/cmd/storage.rs b/crates/cast/bin/cmd/storage.rs
-index 676d9e4db1f..94efe374ce0 100644
+index 676d9e4d..94efe374 100644
 --- a/crates/cast/bin/cmd/storage.rs
 +++ b/crates/cast/bin/cmd/storage.rs
 @@ -217,7 +217,7 @@ async fn fetch_storage_slots(
@@ -318,10 +318,10 @@ index 676d9e4db1f..94efe374ce0 100644
 -        return Ok(());
 +        return Ok(())
      }
-
+ 
      let mut table = Table::new();
 diff --git a/crates/cast/src/rlp_converter.rs b/crates/cast/src/rlp_converter.rs
-index 3a520844d76..c67c99cf520 100644
+index 3a520844..c67c99cf 100644
 --- a/crates/cast/src/rlp_converter.rs
 +++ b/crates/cast/src/rlp_converter.rs
 @@ -24,7 +24,7 @@ impl Decodable for Item {
@@ -334,7 +334,7 @@ index 3a520844d76..c67c99cf520 100644
          let mut d = &buf[..h.payload_length];
          let r = if h.list {
 diff --git a/crates/cheatcodes/spec/src/vm.rs b/crates/cheatcodes/spec/src/vm.rs
-index a9421d087da..676640a2e30 100644
+index a9421d08..676640a2 100644
 --- a/crates/cheatcodes/spec/src/vm.rs
 +++ b/crates/cheatcodes/spec/src/vm.rs
 @@ -47,6 +47,8 @@ interface Vm {
@@ -347,7 +347,7 @@ index a9421d087da..676640a2e30 100644
          Create,
          /// The account was selfdestructed.
 diff --git a/crates/cheatcodes/src/inspector.rs b/crates/cheatcodes/src/inspector.rs
-index 2eef1975502..9151c1d8b70 100644
+index 2eef1975..9151c1d8 100644
 --- a/crates/cheatcodes/src/inspector.rs
 +++ b/crates/cheatcodes/src/inspector.rs
 @@ -826,6 +826,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
@@ -359,7 +359,7 @@ index 2eef1975502..9151c1d8b70 100644
              // Record this call by pushing it to a new pending vector; all subsequent calls at
              // that depth will be pushed to the same vector. When the call ends, the
 diff --git a/crates/cheatcodes/src/string.rs b/crates/cheatcodes/src/string.rs
-index f55350592ea..d40e1d8d2f1 100644
+index f5535059..d40e1d8d 100644
 --- a/crates/cheatcodes/src/string.rs
 +++ b/crates/cheatcodes/src/string.rs
 @@ -138,7 +138,7 @@ fn parse_value_fallback(s: &str, ty: &DynSolType) -> Option<Result<DynSolValue,
@@ -372,20 +372,20 @@ index f55350592ea..d40e1d8d2f1 100644
          DynSolType::Int(_) |
          DynSolType::Uint(_) |
 diff --git a/crates/cheatcodes/src/test/expect.rs b/crates/cheatcodes/src/test/expect.rs
-index bdecef14204..64266ae319e 100644
+index bdecef14..64266ae3 100644
 --- a/crates/cheatcodes/src/test/expect.rs
 +++ b/crates/cheatcodes/src/test/expect.rs
 @@ -457,7 +457,7 @@ pub(crate) fn handle_expect_revert(
-
+ 
      // If None, accept any revert
      let Some(expected_revert) = expected_revert else {
 -        return Ok(success_return());
 +        return Ok(success_return())
      };
-
+ 
      if !expected_revert.is_empty() && retdata.is_empty() {
 diff --git a/crates/common/src/fmt/dynamic.rs b/crates/common/src/fmt/dynamic.rs
-index 2e30f2f7e5e..d8a8d2072ec 100644
+index 2e30f2f7..d8a8d207 100644
 --- a/crates/common/src/fmt/dynamic.rs
 +++ b/crates/common/src/fmt/dynamic.rs
 @@ -41,7 +41,7 @@ impl DynValueFormatter {
@@ -395,10 +395,10 @@ index 2e30f2f7e5e..d8a8d2072ec 100644
 -                    return self.tuple(tuple, f);
 +                    return self.tuple(tuple, f)
                  }
-
+ 
                  f.write_str(name)?;
 diff --git a/crates/common/src/fmt/mod.rs b/crates/common/src/fmt/mod.rs
-index fbe1670fc6c..ea03a98274d 100644
+index fbe1670f..ea03a982 100644
 --- a/crates/common/src/fmt/mod.rs
 +++ b/crates/common/src/fmt/mod.rs
 @@ -68,7 +68,7 @@ pub fn format_uint_exp(num: U256) -> String {
@@ -408,10 +408,10 @@ index fbe1670fc6c..ea03a98274d 100644
 -        return format!("{sign}{abs}");
 +        return format!("{sign}{abs}")
      }
-
+ 
      let exp = to_exp_notation(abs, 4, true, sign);
 diff --git a/crates/common/src/provider.rs b/crates/common/src/provider.rs
-index 730260d9ab4..bea5e18bc58 100644
+index 730260d9..bea5e18b 100644
 --- a/crates/common/src/provider.rs
 +++ b/crates/common/src/provider.rs
 @@ -302,7 +302,7 @@ fn resolve_path(path: &Path) -> Result<PathBuf, ()> {
@@ -424,13 +424,13 @@ index 730260d9ab4..bea5e18bc58 100644
      }
      Err(())
 diff --git a/crates/config/src/lib.rs b/crates/config/src/lib.rs
-index 5175775315d..31b1bd423cf 100644
+index 51757753..31b1bd42 100644
 --- a/crates/config/src/lib.rs
 +++ b/crates/config/src/lib.rs
 @@ -369,6 +369,9 @@ pub struct Config {
      /// Should be removed once EvmVersion Cancun is supported by solc
      pub cancun: bool,
-
+ 
 +    /// Temporary config to enable [SpecId::PRAGUE]
 +    pub prague: bool,
 +
@@ -457,7 +457,7 @@ index 5175775315d..31b1bd423cf 100644
              src: "src".into(),
              test: "test".into(),
 diff --git a/crates/debugger/src/tui.rs b/crates/debugger/src/tui.rs
-index 7cd2b67efd0..9d9fbfcab82 100644
+index 7cd2b67e..9d9fbfca 100644
 --- a/crates/debugger/src/tui.rs
 +++ b/crates/debugger/src/tui.rs
 @@ -677,6 +677,7 @@ Line::from(Span::styled("[t]: stack labels | [m]: memory decoding | [shift + j/k
@@ -467,7 +467,7 @@ index 7cd2b67efd0..9d9fbfcab82 100644
 +                CallKind::AuthCall => "Contract authcall",
              })
              .borders(Borders::ALL);
-
+ 
 @@ -1257,7 +1258,8 @@ Line::from(Span::styled("[t]: stack labels | [m]: memory decoding | [shift + j/k
                                      (i == (offset + size - 1) / 32 &&
                                          j <= (offset + size - 1) % 32)
@@ -479,7 +479,7 @@ index 7cd2b67efd0..9d9fbfcab82 100644
                                      // falls in this region, set the color.
                                      Style::default().fg(color)
 diff --git a/crates/doc/src/builder.rs b/crates/doc/src/builder.rs
-index 692e69b82e1..1826f3518f6 100644
+index 692e69b8..1826f351 100644
 --- a/crates/doc/src/builder.rs
 +++ b/crates/doc/src/builder.rs
 @@ -133,13 +133,13 @@ impl DocBuilder {
@@ -499,7 +499,7 @@ index 692e69b82e1..1826f3518f6 100644
                      }
                  };
 diff --git a/crates/doc/src/preprocessor/contract_inheritance.rs b/crates/doc/src/preprocessor/contract_inheritance.rs
-index 7b4b28e10e0..b4972ac9017 100644
+index 7b4b28e1..b4972ac9 100644
 --- a/crates/doc/src/preprocessor/contract_inheritance.rs
 +++ b/crates/doc/src/preprocessor/contract_inheritance.rs
 @@ -54,7 +54,7 @@ impl ContractInheritance {
@@ -512,7 +512,7 @@ index 7b4b28e10e0..b4972ac9017 100644
              if let DocumentContent::Single(ref item) = candidate.content {
                  if let ParseSource::Contract(ref contract) = item.source {
 diff --git a/crates/doc/src/preprocessor/git_source.rs b/crates/doc/src/preprocessor/git_source.rs
-index eaa53e6268d..a72764c6548 100644
+index eaa53e62..a72764c6 100644
 --- a/crates/doc/src/preprocessor/git_source.rs
 +++ b/crates/doc/src/preprocessor/git_source.rs
 @@ -29,7 +29,7 @@ impl Preprocessor for GitSource {
@@ -525,7 +525,7 @@ index eaa53e6268d..a72764c6548 100644
                  let git_url = format!(
                      "{repo}/blob/{commit}/{}",
 diff --git a/crates/evm/core/src/decode.rs b/crates/evm/core/src/decode.rs
-index 6812cfd4f50..3d09bb51b7d 100644
+index 6812cfd4..3d09bb51 100644
 --- a/crates/evm/core/src/decode.rs
 +++ b/crates/evm/core/src/decode.rs
 @@ -57,7 +57,7 @@ pub fn maybe_decode_revert(
@@ -538,19 +538,19 @@ index 6812cfd4f50..3d09bb51b7d 100644
          }
          return if err.is_empty() {
 @@ -69,12 +69,12 @@ pub fn maybe_decode_revert(
-
+ 
      if err == crate::constants::MAGIC_SKIP {
          // Also used in forge fuzz runner
 -        return Some("SKIPPED".to_string());
 +        return Some("SKIPPED".to_string())
      }
-
+ 
      // Solidity's `Error(string)` or `Panic(uint256)`
      if let Ok(e) = alloy_sol_types::GenericContractError::abi_decode(err, false) {
 -        return Some(e.to_string());
 +        return Some(e.to_string())
      }
-
+ 
      let (selector, data) = err.split_at(SELECTOR_LEN);
 @@ -84,17 +84,17 @@ pub fn maybe_decode_revert(
          // `CheatcodeError(string)`
@@ -582,22 +582,22 @@ index 6812cfd4f50..3d09bb51b7d 100644
              }
          }
      }
-
+ 
      // ABI-encoded `string`
      if let Ok(s) = String::abi_decode(err, false) {
 -        return Some(s);
 +        return Some(s)
      }
-
+ 
      // UTF-8-encoded string
      if let Ok(s) = std::str::from_utf8(err) {
 -        return Some(s.to_string());
 +        return Some(s.to_string())
      }
-
+ 
      // Generic custom error
 diff --git a/crates/evm/core/src/opts.rs b/crates/evm/core/src/opts.rs
-index 1ccac43d422..dd99a391fb7 100644
+index 1ccac43d..dd99a391 100644
 --- a/crates/evm/core/src/opts.rs
 +++ b/crates/evm/core/src/opts.rs
 @@ -182,14 +182,14 @@ impl EvmOpts {
@@ -610,15 +610,15 @@ index 1ccac43d422..dd99a391fb7 100644
              trace!(?url, "retrieving chain via eth_chainId");
              let provider = Provider::try_from(url.as_str())
                  .unwrap_or_else(|_| panic!("Failed to establish provider to {url}"));
-
+ 
              if let Ok(id) = RuntimeOrHandle::new().block_on(provider.get_chainid()) {
 -                return Some(Chain::from(id.as_u64()));
 +                return Some(Chain::from(id.as_u64()))
              }
          }
-
+ 
 diff --git a/crates/evm/core/src/utils.rs b/crates/evm/core/src/utils.rs
-index 8edaa4e21e0..879d09774e4 100644
+index 8edaa4e2..879d0977 100644
 --- a/crates/evm/core/src/utils.rs
 +++ b/crates/evm/core/src/utils.rs
 @@ -22,6 +22,7 @@ pub enum CallKind {
@@ -669,7 +669,7 @@ index 8edaa4e21e0..879d09774e4 100644
          Halt::OutOfFund => InstructionResult::OutOfFund,
          Halt::CallTooDeep => InstructionResult::CallTooDeep,
 diff --git a/crates/evm/traces/src/decoder/mod.rs b/crates/evm/traces/src/decoder/mod.rs
-index 2866d8319a3..ece2f13b41b 100644
+index 2866d831..ece2f13b 100644
 --- a/crates/evm/traces/src/decoder/mod.rs
 +++ b/crates/evm/traces/src/decoder/mod.rs
 @@ -460,7 +460,7 @@ impl CallTraceDecoder {
@@ -682,7 +682,7 @@ index 2866d8319a3..ece2f13b41b 100644
          }
          format_token(value)
 diff --git a/crates/evm/traces/src/lib.rs b/crates/evm/traces/src/lib.rs
-index 3d88ee23ff1..4dd1e5ae6e7 100644
+index 3d88ee23..4dd1e5ae 100644
 --- a/crates/evm/traces/src/lib.rs
 +++ b/crates/evm/traces/src/lib.rs
 @@ -535,6 +535,7 @@ impl fmt::Display for CallTrace {
@@ -692,9 +692,9 @@ index 3d88ee23ff1..4dd1e5ae6e7 100644
 +                CallKind::AuthCall => " [authcall]",
                  CallKind::Create | CallKind::Create2 => unreachable!(),
              };
-
+ 
 diff --git a/crates/evm/traces/src/node.rs b/crates/evm/traces/src/node.rs
-index e68840b69e9..b7539027069 100644
+index e68840b6..b7539027 100644
 --- a/crates/evm/traces/src/node.rs
 +++ b/crates/evm/traces/src/node.rs
 @@ -37,12 +37,14 @@ impl CallTraceNode {
@@ -748,20 +748,20 @@ index e68840b69e9..b7539027069 100644
                  from: self.trace.caller.to_ethers(),
                  value: self.trace.value.to_ethers(),
 diff --git a/crates/forge/bin/cmd/script/multi.rs b/crates/forge/bin/cmd/script/multi.rs
-index 7fa4709a963..2eb5e2b4ef7 100644
+index 7fa4709a..2eb5e2b4 100644
 --- a/crates/forge/bin/cmd/script/multi.rs
 +++ b/crates/forge/bin/cmd/script/multi.rs
 @@ -144,7 +144,7 @@ impl ScriptArgs {
                  join_all(futs).await.into_iter().filter(|res| res.is_err()).collect::<Vec<_>>();
-
+ 
              if !errors.is_empty() {
 -                return Err(eyre::eyre!("{errors:?}"));
 +                return Err(eyre::eyre!("{errors:?}"))
              }
          }
-
+ 
 diff --git a/crates/forge/tests/cli/config.rs b/crates/forge/tests/cli/config.rs
-index 27001b73217..30fa8f4d94e 100644
+index 27001b73..30fa8f4d 100644
 --- a/crates/forge/tests/cli/config.rs
 +++ b/crates/forge/tests/cli/config.rs
 @@ -112,6 +112,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {


### PR DESCRIPTION
Bumping revm to include the latest spec changes. Notably:

- Inclusion of `nonce`: https://github.com/wevm/revm/commit/e1a1c3a0c4b17323667691d1c3a2c16e6b7a9b95
- Fix source transfers: https://github.com/wevm/revm/commit/695b3ae3dd7872e8b43f3521af28a43ca033802f
- Omission of `valueExt`: https://github.com/wevm/revm/commit/1ddd520c938bb50ddf4f8493a640f73b0924691c

Also updating README to point to the new repo: https://github.com/anton-rs/3074-invokers (the old `eip-3074-foundry` repo was transferred there). That repo is also pointing to the [updated revm branch](https://github.com/wevm/revm/tree/jxom/eip-3074).