### PR TITLE
feat: support anvil

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -27,7 +27,7 @@ RUN git apply solc.diff && \
     cmake .. -DCMAKE_BUILD_TYPE=Release && \
     make solc
 
-FROM rust:1.76.0-slim-buster as forge-builder
+FROM rust:1.76.0-slim-buster as foundry-builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
@@ -44,18 +44,23 @@ RUN git checkout $FORGE_COMMIT
 COPY ./patches/forge.diff .
 
 RUN git apply forge.diff && \
-  cargo build --bin forge --release
+  cargo build --bin forge --release && \
+  cargo build --bin anvil --release
 
 FROM ubuntu:jammy-20240212
 
 # Copy the compiled solc binary to a standard location
 COPY --from=solc-builder /app/solidity/build/solc/solc /usr/local/bin/solc
-COPY --from=forge-builder /app/foundry/target/release/forge /usr/local/bin/forge
+COPY --from=foundry-builder /app/foundry/target/release/forge /usr/local/bin/forge
+COPY --from=foundry-builder /app/foundry/target/release/anvil /usr/local/bin/anvil
 
 RUN chmod +x /usr/local/bin/solc && \
-    chmod +x /usr/local/bin/forge
+    chmod +x /usr/local/bin/forge && \
+    chmod +x /usr/local/bin/anvil
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+
+EXPOSE 8545
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ docker run --rm \
     -u $(id -u):$(id -g) \
     ghcr.io/paradigmxyz/foundry-alphanet:latest \
     --foundry-directory /app/foundry \
-    --foundry-command build
+    --foundry-command "forge build"
 ```
 In this command:
 * `-v $(pwd):/app/foundry` mounts the local directory in `/app/foundry` in the
@@ -45,8 +45,8 @@ same user executing the command.
 * `ghcr.io/paradigmxyz/foundry-alphanet:latest` is the image name
 * `--foundry-directory /app/foundry` tells the entrypoint script to use
 `/app/foundry` in the container as the foundry project directory.
-* `--foundry-command build` tells the entrypoint script to use `build` as the
-forge command.
+* `--foundry-command "forge build"` tells the entrypoint script to use `forge build` as the
+foundry command.
 
 To run tests in a project, from the projects root:
 ```shell
@@ -55,10 +55,22 @@ $ docker run --rm \
     -u $(id -u):$(id -g) \
     ghcr.io/paradigmxyz/foundry-alphanet:latest \
     --foundry-directory /app/foundry \
-    --foundry-command "test -vvv"
+    --foundry-command "forge test -vvv"
 ```
+
 In this case we have signalled forge that we want increased verbosity in the test
-output passing `test -vvvv` to `--foundry-command`.
+output passing `forge test -vvvv` to `--foundry-command`.
+
+To run Anvil:
+
+```shell
+$ docker run --rm \
+    -v $(pwd):/app/foundry \
+    -u $(id -u):$(id -g) \
+    -p 8545:8545 \
+    ghcr.io/paradigmxyz/foundry-alphanet:latest \
+    --foundry-command "anvil --hardfork prague"
+```
 
 [clabby/eip-3074-foundry]: https://github.com/clabby/eip-3074-foundry
 [EIP-3074]: https://eips.ethereum.org/EIPS/eip-3074

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $ docker run --rm \
     -u $(id -u):$(id -g) \
     -p 8545:8545 \
     ghcr.io/paradigmxyz/foundry-alphanet:latest \
-    --foundry-command "anvil --hardfork prague"
+    --foundry-command "anvil"
 ```
 
 [clabby/eip-3074-foundry]: https://github.com/clabby/eip-3074-foundry

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,13 @@ main() {
     if [ "$FOUNDRY_COMMAND" = "script" ]; then
         exec forge script $FOUNDRY_SCRIPT $SOLC_PATH $FOUNDRY_DIRECTORY --fork-url http://localhost:8545 --broadcast -vvvv
     else
-        exec forge $FOUNDRY_COMMAND $SOLC_PATH $FOUNDRY_DIRECTORY
+        if [[ "$FOUNDRY_COMMAND" =~ ^forge ]]; then
+            exec $FOUNDRY_COMMAND $SOLC_PATH $FOUNDRY_DIRECTORY
+        elif [[ "$FOUNDRY_COMMAND" =~ ^anvil ]]; then
+            exec $FOUNDRY_COMMAND --host 0.0.0.0 --hardfork prague
+        fi
+        echo "Error: 'foundry-command' only supports 'forge' or 'anvil' binaries"
+        exit 1
     fi
 }
 


### PR DESCRIPTION
Adds Anvil support for foundry-alphanet.

```shell
$ docker run --rm \
    -v $(pwd):/app/foundry \
    -u $(id -u):$(id -g) \
    -p 8545:8545 \
    ghcr.io/paradigmxyz/foundry-alphanet:latest \
    --foundry-command "anvil"
```